### PR TITLE
check return code for make check

### DIFF
--- a/runner/run_bench.py
+++ b/runner/run_bench.py
@@ -136,10 +136,7 @@ def run_benches():
 
     if _shouldrun('makecheck'):
         _try_execute_and_report(
-            f'makecheck.{NPROC - 1}', f"make -j {NPROC - 1} check", num_tries=3,
-            # make check seems to return non-zero exit codes even when it has
-            # succeeded.
-            check_returncode=False,
+            f'makecheck.{NPROC - 1}', f"make -j {NPROC - 1} check",
             executable='make')
 
     if _shouldrun('functionaltests'):


### PR DESCRIPTION
make check should never exit with non-zero or fail intermittently. If it does, it should be investigated...