### PR TITLE
Various benchmark consistency fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,6 @@ venv.bak/
 
 # Deploy-specific .env file, potentially containing Codespeed credentials.
 bin/.env
+runner/.env
 
 data.db


### PR DESCRIPTION
as recommended by @TheBlueMatt @MarcoFalke.

Generally, we're dropping the dependency on python3.6 (in lieu of python3.5) so that we're able to run without using Docker in a vanilla Debian 9 environment. This gives us greater control over system caches and swap usage.

Other changes include:

- Manually controlling the synced peer from within this script. Previously, users had to manually start a bitcoind using a datadir that had a chain high enough to service IBD requests for the benchmark; now if we don't specify `IBD_PEER_ADDRESS`,  this script handles setup and teardown of that node - and importantly only does it for benchmarks which require the node.
- Assert that other bitcoin-related processes are not running before starting the benchmark.
- Drop system caches before each separate benchmark.

TODO: update README accordingly.