### PR TITLE
Replace deprecated rpcuser with cookie auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The benchmarks which are monitored are
 0. [assuming you have obtained a relatively up-to-date chain in `$datadir`]
 0. In a separate terminal window, run `./bin/start_synced $datadir`
 0. Ensure the peer is up by running
-   `/path/to/bitcoin-cli -rpcport=9001 -rpcuser=foo -rpcpassword=bar getblockchaininfo`.
+   `/path/to/bitcoin-cli -rpcport=9001 -datadir="${datadir}" getblockchaininfo`.
 
 
 #### Running the benchmarks

--- a/bin/start_synced
+++ b/bin/start_synced
@@ -10,5 +10,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 [ -f "${DIR}/.env" ] && source "${DIR}/.env"
 
 ${BITCOIND_PATH:-~/src/bitcoin/src/bitcoind} -datadir="$1" -printtoconsole \
-  -rpcuser=foo -rpcpassword=bar -port=9000 -rpcport=9001 -noconnect -listen=1 \
+  -port=9000 -rpcport=9001 -noconnect -listen=1 \
   -maxtipage=9999999999999

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ./runner
     command: |
       /bitcoin/src/bitcoind -datadir=/bitcoin_data -printtoconsole
-      -rpcuser=foo -rpcpassword=bar -noconnect -listen=1
+      -noconnect -listen=1
       -maxtipage=9999999999999 
     volumes:
       - "${SYNCED_DATADIR}:/bitcoin_data"

--- a/runner/run_bench.py
+++ b/runner/run_bench.py
@@ -56,8 +56,6 @@ BITCOIND_DBCACHE = os.environ.get('BITCOIND_DBCACHE', '2048')
 BITCOIND_STOPATHEIGHT = os.environ.get('BITCOIND_STOPATHEIGHT', '522000')
 BITCOIND_PORT = os.environ.get('BITCOIND_PORT', '9003')
 BITCOIND_RPCPORT = os.environ.get('BITCOIND_RPCPORT', '9004')
-BITCOIND_RPCUSER = os.environ.get('BITCOIND_RPCUSER', 'foo')
-BITCOIND_RPCPASSWORD = os.environ.get('BITCOIND_RPCPASSWORD', 'bar')
 
 # Where the bitcoind binary which will serve blocks for IBD lives.
 SYNCED_BITCOIN_REPO_DIR = os.environ.get(

--- a/runner/run_bench.py
+++ b/runner/run_bench.py
@@ -176,10 +176,10 @@ def run_synced_bitcoind():
         # Relies on bitcoind being precompiled and synced chain data existing
         # in /bitcoin_data; see runner/Dockerfile.
         "%s/src/bitcoind -datadir=%s "
-        "-rpcuser=%s -rpcpassword=%s -noconnect -listen=1 "
+        "-noconnect -listen=1 "
         "-maxtipage=99999999999999" % (
             SYNCED_BITCOIN_REPO_DIR, SYNCED_DATA_DIR,
-            BITCOIND_RPCUSER, BITCOIND_RPCPASSWORD))
+            ))
 
     logger.info(
         "started synced node with '%s' (pid %s)",
@@ -193,8 +193,8 @@ def run_synced_bitcoind():
     while num_tries > 0 and bitcoinps.returncode is None and not bitcoind_up:
         info = None
         info_call = _run(
-            "%s/src/bitcoin-cli -rpcuser=foo -rpcpassword=bar "
-            "getblockchaininfo" % SYNCED_BITCOIN_REPO_DIR,
+            "%s/src/bitcoin-cli -datadir=%s "
+            "getblockchaininfo" % SYNCED_BITCOIN_REPO_DIR, SYNCED_DATA_DIR,
             check_returncode=False)
 
         if info_call[2] == 0:
@@ -224,8 +224,8 @@ def run_synced_bitcoind():
     finally:
         logger.info("shutting down synced node (pid %s)", bitcoinps.pid)
         _run(
-            "%s/src/bitcoin-cli -rpcuser=foo -rpcpassword=bar stop" %
-            SYNCED_BITCOIN_REPO_DIR)
+            "%s/src/bitcoin-cli -datadir=%s stop" %
+            SYNCED_BITCOIN_REPO_DIR, SYNCED_DATA_DIR)
         bitcoinps.wait(timeout=120)
 
         if bitcoinps.returncode != 0:
@@ -378,10 +378,9 @@ def run_benches():
     run_bitcoind_cmd = (
         './src/bitcoind -datadir=%s/bitcoin/data '
         '-dbcache=%s -txindex=1 '
-        '-rpcusername=%s -rpcpassword=%s '
         '-connect=0 -debug=all -stopatheight=%s '
         '-port=%s -rpcport=%s' % (
-            workdir, BITCOIND_DBCACHE, BITCOIND_RPCUSER, BITCOIND_RPCPASSWORD,
+            workdir, BITCOIND_DBCACHE,
             BITCOIND_STOPATHEIGHT,
             BITCOIND_PORT, BITCOIND_RPCPORT
         ))


### PR DESCRIPTION
Commit a1b8df71a199c591b3b2c2b40f50cdc712c9d has a typo "rpcusername", which would likely cause the syncing node to fall back to cookie auth.

It seems easier to me to just call `bitcoin-cli -datadir=${workdir}/bitcoin/data -rpcport=9004` instead of specifying the rpcuser and pass. Note that they are also identical for the syncing and synced peer, which might lead to issues.